### PR TITLE
add base_url instead of / to site-title

### DIFF
--- a/themes/Travelify/index.twig
+++ b/themes/Travelify/index.twig
@@ -28,7 +28,7 @@
                 <section class="hgroup-right">
                 </section>
                 <hgroup id="site-logo" class="clearfix">
-                    <h1 id="site-title"><a href="/">{{ site_title }}</a></h1>
+                    <h1 id="site-title"><a href={{ base_url }}>{{ site_title }}</a></h1>
                     <h2 id="site-description">{{ config.site_subtitle }}</h2>
                 </hgroup>
             </div>

--- a/themes/Travelify/index.twig
+++ b/themes/Travelify/index.twig
@@ -86,7 +86,7 @@
     <footer id="footerarea" class="clearfix">
         <div id="site-generator">
             <div class="container">
-                <div class="copyright">Copyright &copy; 2016 <span>{{ config.site_copyright }}</span>.
+                <div class="copyright">Copyright &copy; 2017 <span>{{ config.site_copyright }}</span>.
                 </div>
                 <div class="footer-right">Theme <a href="https://github.com/xupefei/Travelify">Travelify</a> ported by Paddy Xu.</div>
                 <div style="clear:both;"></div>


### PR DESCRIPTION
otherwise, if your page isn't on the base url, the user is distracted off that page when clicking on the title.
If not desired, the alternative would be to make this URL configurable in config.php just like config.site_subtitle (e.g. config.site_title_link).